### PR TITLE
WT-6664 fetch posted time first draft

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -152,7 +152,7 @@ paths:
     get:
       operationId: fetch-posted-time
       summary: Returns posted time for the team associated with the provided api key.
-      description: This is a long polling call. The connection will be held open until there is a new posted time event. This is an alternative for the webhook mechanism.
+      description: This is a long polling call. The connection will be held open for a maximum of 60 seconds or until there is a new posted time event. This is an alternative for the webhook mechanism.
       tags:
         - Posted Time
       parameters:
@@ -161,7 +161,7 @@ paths:
           schema:
             type: integer
           required: false
-          description: Maximum amount of posted time entries to retrieve. If not set or 0 all available will be returned.
+          description: Maximum amount of posted time entries to retrieve. If not set, the API will return up to a maximum of 25 entries for each request.
       responses:
         '200': 
           description: List of posted time events.
@@ -172,7 +172,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/TimeGroup'
         '400':
-          description: Invalid request. Limit cannot be smaller than 0.
+          description: Invalid request. Limit cannot be smaller than 1.
         '401':
           description: A valid API key is required to access this resource.
         '500':

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -148,6 +148,36 @@ paths:
         '500':
           description: An unexpected error occured.
 
+  /postedtime:
+    get:
+      operationId: fetch-posted-time
+      summary: Returns posted time for the team associated with the provided api key.
+      description: This is a long polling call. The connection will be held open until there is a new posted time event. This is an alternative for the webhook mechanism.
+      tags:
+        - Posted Time
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+          required: false
+          description: Maximum amount of posted time entries to retrieve. If not set or 0 all available will be returned.
+      responses:
+        '200': 
+          description: List of posted time events.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TimeGroup'
+        '400':
+          description: Invalid request. Limit cannot be smaller than 0.
+        '401':
+          description: A valid API key is required to access this resource.
+        '500':
+          description: An unexpected error occured.  
+
   /postedtime/subscribe:
     post:
       operationId: post-subscribe

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: WiseTime Connect API
-  version: "1.1.0"
+  version: "1.2.0"
   description: >-
     Use the WiseTime Connect API to build connectors to your application.
   contact:


### PR DESCRIPTION
Went through wt-integrate-agents and wt-integrate-service to get the details of how it was done in the past.
Looks like we used a grpc for this.
Anyways, this time we should get away with simple get request. I also introduced a "limit" query parameter to set the max amount of time groups to be retrieved (was also present in the old implementation)