### PR TITLE
add status endpoint

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -187,7 +187,7 @@ paths:
   /postedtime/registerFetchClient:
     post:
       operationId: register-for-fetch
-      summary: Register the intend to fetch time from the /postedtime endpoint.
+      summary: Register the intent to fetch time from the /postedtime endpoint.
       description: WiseTime will start recording posted time events that can be fetched via the /postedtime endpoint.
       tags:
         - Posted Time
@@ -228,7 +228,7 @@ paths:
               $ref: '#/components/schemas/UnregisterFetchClientRequest'
       responses:
         '200':
-          description: Fetch client successfully deleted.
+          description: Fetch client successfully unregistered.
           content:
             application/json:
               schema:
@@ -577,7 +577,7 @@ components:
       properties:
         fetchClientId:
           type: string
-          description: The ID of the fetch client to be deleted.
+          description: The ID of the fetch client to be unregistered.
     UnregisterFetchClientResult:
       type: object
     TimeGroupStatus:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -148,14 +148,20 @@ paths:
         '500':
           description: An unexpected error occured.
 
-  /postedtime:
+  /postedtime/{fetchClientId}:
     get:
       operationId: fetch-posted-time
-      summary: Returns posted time for the team associated with the provided api key.
+      summary: Returns posted time for the registered fetch client provided in the url.
       description: This is a long polling call. The connection will be held open for a maximum of 60 seconds or until there is a new posted time event. This is an alternative for the webhook mechanism.
       tags:
         - Posted Time
       parameters:
+        - in: path
+          name: fetchClientId
+          schema:
+            type: string
+          required: true
+          description: The id of the registered fetch client.
         - in: query
           name: limit
           schema:
@@ -178,10 +184,67 @@ paths:
         '500':
           description: An unexpected error occured.
 
+  /postedtime/registerFetchClient:
+    post:
+      operationId: register-for-fetch
+      summary: Register the intend to fetch time from the /postedtime endpoint.
+      description: WiseTime will start recording posted time events that can be fetched via the /postedtime endpoint.
+      tags:
+        - Posted Time
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterFetchClientRequest'
+      responses:
+        '200':
+          description: Fetch client successfully registered.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegisterFetchClientResult'
+        '400':
+          description: Invalid request. Callback URL is required.
+        '409':
+          description: This team already has a registered fetch client or webhook.
+        '401':
+          description: A valid API key is required to access this resource.
+        '500':
+          description: An unexpected error occured.
+
+  /postedtime/unregisterFetchClient:
+    post:
+      operationId: unregister-from-fetch
+      summary: Delete existing fetch client by id, unsubscribing your application from posted time fetching.
+      description: WiseTime will stop recording posted time events for fetch when users post time to your team.
+      tags:
+        - Posted Time
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UnregisterFetchClientRequest'
+      responses:
+        '200':
+          description: Fetch client successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnregisterFetchClientResult'
+        '401':
+          description: A valid API key is required to access this resource.
+        '404':
+          description: Fetch client not found.
+        '500':
+          description: An unexpected error occured.
+
   /postedtime/status:
     post:
       operationId: update-posted-time-status
       summary: Updates the status of the received time groups.
+      description: This is intended for use with the fetch mechanism only. Not to be used with webhooks.
       tags:
         - Posted Time
       requestBody:
@@ -222,7 +285,7 @@ paths:
         '400':
           description: Invalid request. Callback URL is required.
         '409':
-          description: This team already has a registered webhook.
+          description: This team already has a registered webhook or fetch client.
         '401':
           description: A valid API key is required to access this resource.
         '500':
@@ -489,6 +552,13 @@ components:
       properties:
         webhookId:
           type: string
+    RegisterFetchClientRequest:
+      type: object
+    RegisterFetchClientResult:
+      type: object
+      properties:
+        fetchClientId:
+          type: string
     TeamInfoResult:
       type: object
       properties:
@@ -502,6 +572,14 @@ components:
           description: The ID of the webhook to be deleted.
     UnsubscribeResult:
       type: object
+    UnregisterFetchClientRequest:
+      type: object
+      properties:
+        fetchClientId:
+          type: string
+          description: The ID of the fetch client to be deleted.
+    UnregisterFetchClientResult:
+      type: object
     TimeGroupStatus:
       type: array
       items:
@@ -510,6 +588,9 @@ components:
           timeGroupId:
             type: string
             description: ID of the time group to be updated.
+          fetchClientId:
+            type: string
+            description: The id of the fetch client that received this time group.
           status:
             type: string
             enum:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -191,7 +191,7 @@ paths:
               $ref: '#/components/schemas/TimeGroupStatus'
       responses:
         '200':
-          description: Status of time groups was updates successfully.
+          description: Status of time groups was updated successfully.
         '400':
           description: Invalid request.
         '401':

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -178,6 +178,27 @@ paths:
         '500':
           description: An unexpected error occured.
 
+  /postedtime/status:
+    post:
+      operationId: update-posted-time-status
+      summary: Updates the status of the received time groups.
+      tags:
+        - Posted Time
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TimeGroupStatus'
+      responses:
+        '200':
+          description: Status of time groups was updates successfully.
+        '400':
+          description: Invalid request.
+        '401':
+          description: A valid API key is required to access this resource.
+        '500':
+          description: An unexpected error occured.
+
   /postedtime/subscribe:
     post:
       operationId: post-subscribe
@@ -481,6 +502,26 @@ components:
           description: The ID of the webhook to be deleted.
     UnsubscribeResult:
       type: object
+    TimeGroupStatus:
+      type: array
+      items:
+        type: object
+        properties:
+          timeGroupId:
+            type: string
+            description: ID of the time group to be updated.
+          status:
+            type: string
+            enum:
+              - SUCCESS
+              - FAILURE
+            description: >
+              This field describes the status of the posted time group.
+              On SUCCESS the time group will be marked as successfully posted.
+              On FAILURE the time group will be marked as failed and the attached message will displayed to the user.
+          message:
+            type: string
+            description: Reason for the failure, will be displayed to the user.
 security:
   # the API key is required for all operations
   - ConnectApiKeyAuth: []


### PR DESCRIPTION
@vyshane 
we need the endpoint to update the status of a time group from the connectors in any case.

I chose to use an enum for the status in case we want to add a temporary failure state for connectors.
Earlier I thought I had a use case for it, but not so sure anymore. Anyways, better safe than sorry -> enum