### PR TITLE
Feature/wt 8003 create cloud watch alerts

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -490,7 +490,7 @@ components:
           type: string
           format: date-time
           description: The date which the current credentials will expire.
-        serviceSession:
+        serviceSessionToken:
           type: string
           description: The token that the service must pass to the API to use the security credentials.
         groupName:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -482,14 +482,22 @@ components:
       properties:
         serviceId:
           type: string
+          description: Service ID that identifies the security credentials.
         serviceKey:
           type: string
+          description: Secret key for the security credentials.
         serviceIdExpiry:
           type: string
           format: date-time
+          description: The date which the current credentials will expire.
+        serviceSession:
+          type: string
+          description: The token that the service must pass to the API to use the security credentials.
         groupName:
           type: string
+          description: The name of the group for logging.
         regionName:
+          description: Geographic area for the logging.
           type: string
     TimeGroup:
       type: object


### PR DESCRIPTION
ServiceSessionToken field required to provide temporary security credentials so that the AWS logs client can send authenticated requests.